### PR TITLE
First-party bundle packages should be cross platform

### DIFF
--- a/examples/basic-browser-js/.gitignore
+++ b/examples/basic-browser-js/.gitignore
@@ -1,3 +1,3 @@
 dist/pandino-bundle-installer-dom-manifest.json
-dist/pandino-bundle-installer-dom.js
+dist/pandino-bundle-installer-dom.mjs
 dist/pandino.mjs

--- a/examples/basic-browser-js/cp-extra-manifests.sh
+++ b/examples/basic-browser-js/cp-extra-manifests.sh
@@ -3,4 +3,4 @@
 cp ../../packages/@pandino/pandino/dist/esm/pandino.mjs dist/pandino.mjs
 
 cp ../../packages/@pandino/pandino-bundle-installer-dom/dist/pandino-bundle-installer-dom-manifest.json dist/pandino-bundle-installer-dom-manifest.json
-cp ../../packages/@pandino/pandino-bundle-installer-dom/dist/pandino-bundle-installer-dom.js dist/pandino-bundle-installer-dom.js
+cp ../../packages/@pandino/pandino-bundle-installer-dom/dist/pandino-bundle-installer-dom.mjs dist/pandino-bundle-installer-dom.mjs

--- a/examples/basic-browser-ts/package-lock.json
+++ b/examples/basic-browser-ts/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "basic-browser-ts",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "MIT",

--- a/examples/basic-browser-ts/packages/app/cp-bundle-installer.sh
+++ b/examples/basic-browser-ts/packages/app/cp-bundle-installer.sh
@@ -4,5 +4,5 @@ rm -rf assets/deploy
 mkdir -p assets/deploy
 
 cp ../../../../packages/@pandino/pandino-bundle-installer-dom/dist/pandino-bundle-installer-dom-manifest.json assets/deploy/pandino-bundle-installer-dom-manifest.json
-cp ../../../../packages/@pandino/pandino-bundle-installer-dom/dist/pandino-bundle-installer-dom.js assets/deploy/pandino-bundle-installer-dom.js
+cp ../../../../packages/@pandino/pandino-bundle-installer-dom/dist/pandino-bundle-installer-dom.mjs assets/deploy/pandino-bundle-installer-dom.mjs
 

--- a/examples/configuration-manager-browser-js/cp-extra-manifests.sh
+++ b/examples/configuration-manager-browser-js/cp-extra-manifests.sh
@@ -6,7 +6,7 @@ cp ../../packages/@pandino/pandino-bundle-installer-dom/dist/pandino-bundle-inst
 cp ../../packages/@pandino/pandino-bundle-installer-dom/dist/pandino-bundle-installer-dom.js dist/pandino-bundle-installer-dom.js
 
 cp ../../packages/@pandino/pandino-configuration-management/dist/pandino-configuration-management-manifest.json dist/pandino-configuration-management-manifest.json
-cp ../../packages/@pandino/pandino-configuration-management/dist/pandino-configuration-management.js dist/pandino-configuration-management.js
+cp ../../packages/@pandino/pandino-configuration-management/dist/pandino-configuration-management.mjs dist/pandino-configuration-management.mjs
 
 cp ../../packages/@pandino/pandino-persistence-manager-localstorage/dist/pandino-persistence-manager-localstorage-manifest.json dist/pandino-persistence-manager-localstorage-manifest.json
-cp ../../packages/@pandino/pandino-persistence-manager-localstorage/dist/pandino-persistence-manager-localstorage.js dist/pandino-persistence-manager-localstorage.js
+cp ../../packages/@pandino/pandino-persistence-manager-localstorage/dist/pandino-persistence-manager-localstorage.mjs dist/pandino-persistence-manager-localstorage.mjs

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,9 @@
 			}
 		},
 		"node_modules/@ampproject/remapping": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.4.tgz",
-			"integrity": "sha512-zU3pj3pf//YhaoozRTYKaL20KopXrzuZFc/8Ylc49AuV8grYKH23TTq9JJoR70F8zQbil58KjSchZTWeX+jrIQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.0.tgz",
+			"integrity": "sha512-d5RysTlJ7hmw5Tw4UxgxcY3lkMe92n8sXCcuLPAyIAHK6j8DefDwtGnVVDgOnv+RnEosulDJ9NPKQL27bDId0g==",
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.0"
 			},
@@ -3225,9 +3225,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001307",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001307.tgz",
-			"integrity": "sha512-+MXEMczJ4FuxJAUp0jvAl6Df0NI/OfW1RWEE61eSmzS7hw6lz4IKutbhbXendwq8BljfFuHtu26VWsg4afQ7Ng==",
+			"version": "1.0.30001309",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
+			"integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA==",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/browserslist"
@@ -11308,9 +11308,9 @@
 	},
 	"dependencies": {
 		"@ampproject/remapping": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.0.4.tgz",
-			"integrity": "sha512-zU3pj3pf//YhaoozRTYKaL20KopXrzuZFc/8Ylc49AuV8grYKH23TTq9JJoR70F8zQbil58KjSchZTWeX+jrIQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.0.tgz",
+			"integrity": "sha512-d5RysTlJ7hmw5Tw4UxgxcY3lkMe92n8sXCcuLPAyIAHK6j8DefDwtGnVVDgOnv+RnEosulDJ9NPKQL27bDId0g==",
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.0"
 			}
@@ -13925,9 +13925,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001307",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001307.tgz",
-			"integrity": "sha512-+MXEMczJ4FuxJAUp0jvAl6Df0NI/OfW1RWEE61eSmzS7hw6lz4IKutbhbXendwq8BljfFuHtu26VWsg4afQ7Ng=="
+			"version": "1.0.30001309",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001309.tgz",
+			"integrity": "sha512-Pl8vfigmBXXq+/yUz1jUwULeq9xhMJznzdc/xwl4WclDAuebcTHVefpz8lE/bMI+UN7TOkSSe7B7RnZd6+dzjA=="
 		},
 		"caseless": {
 			"version": "0.12.0",

--- a/packages/@pandino/pandino-bundle-installer-dom/assets/pandino-bundle-installer-dom-manifest.json
+++ b/packages/@pandino/pandino-bundle-installer-dom/assets/pandino-bundle-installer-dom-manifest.json
@@ -4,5 +4,5 @@
   "Bundle-Name": "Pandino Bundle Installer DOM",
   "Bundle-Version": "0.1.0",
   "Bundle-Description": "Install Bundles defined in a browser's DOM",
-  "Bundle-Activator": "./pandino-bundle-installer-dom.js"
+  "Bundle-Activator": "./pandino-bundle-installer-dom.mjs"
 }

--- a/packages/@pandino/pandino-bundle-installer-dom/package.json
+++ b/packages/@pandino/pandino-bundle-installer-dom/package.json
@@ -2,7 +2,13 @@
   "name": "@pandino/pandino-bundle-installer-dom",
   "version": "0.1.0",
   "description": "",
-  "main": "dist/pandino-bundle-installer-dom.js",
+  "type": "module",
+  "module": "./dist/pandino-bundle-installer-dom.mjs",
+  "exports": {
+    ".": {
+      "default": "./dist/pandino-bundle-installer-dom.mjs"
+    }
+  },
   "private": true,
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/@pandino/pandino-bundle-installer-dom/webpack.config.js
+++ b/packages/@pandino/pandino-bundle-installer-dom/webpack.config.js
@@ -1,8 +1,13 @@
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-const path = require('path');
-const CopyPlugin = require('copy-webpack-plugin');
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+import path from 'path';
+import CopyPlugin from 'copy-webpack-plugin';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 
-module.exports = {
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default {
   experiments: {
     outputModule: true,
   },
@@ -24,10 +29,8 @@ module.exports = {
     extensions: ['.tsx', '.ts', '.js'],
   },
   output: {
-    filename: '[name].js',
-    library: {
-      type: 'module',
-    },
+    filename: '[name].mjs',
+    libraryTarget: 'module',
     umdNamedDefine: true,
     path: path.resolve(__dirname, 'dist'),
   },

--- a/packages/@pandino/pandino-configuration-management/assets/manifest.hbs
+++ b/packages/@pandino/pandino-configuration-management/assets/manifest.hbs
@@ -1,10 +1,10 @@
 {
   "Bundle-ManifestVersion": "1",
-  "Bundle-SymbolicName": "@pandino/pandino-configuration-management",
+  "Bundle-SymbolicName": "{{ name }}",
   "Bundle-Name": "Pandino Configuration Management",
-  "Bundle-Version": "0.1.0",
-  "Bundle-Description": "Pandino reference implementation for Configuration Management",
-  "Bundle-Activator": "./pandino-configuration-management.js",
+  "Bundle-Version": "{{ version }}",
+  "Bundle-Description": "{{ description }}",
+  "Bundle-Activator": "./{{ entryName }}.{{ extension }}",
   "Require-Capability": "@pandino/persistence-manager;filter:=(objectClass=\"@pandino/persistence-manager/PersistenceManager\")",
   "Provide-Capability": "@pandino/pandino-configuration-management;objectClass:Array=\"@pandino/pandino-configuration-management/ConfigurationAdmin,@pandino/pandino-configuration-management/ManagedService,@pandino/pandino-configuration-management/ConfigurationListener\""
 }

--- a/packages/@pandino/pandino-configuration-management/package.json
+++ b/packages/@pandino/pandino-configuration-management/package.json
@@ -2,7 +2,14 @@
   "name": "@pandino/pandino-configuration-management",
   "version": "0.1.0",
   "description": "",
-  "main": "dist/pandino-configuration-management.js",
+  "main": "./dist/cjs/pandino-configuration-management.js",
+  "module": "./dist/esm/pandino-configuration-management.mjs",
+  "exports": {
+    ".": {
+      "require": "./dist/cjs/pandino-configuration-management.js",
+      "default": "./dist/esm/pandino-configuration-management.mjs"
+    }
+  },
   "private": true,
   "types": "dist/src/index.d.ts",
   "scripts": {
@@ -24,6 +31,7 @@
     "@types/jest": "^27.4.0",
     "@types/semver": "^7.3.9",
     "copy-webpack-plugin": "^10.2.0",
+    "handlebars-webpack-plugin": "^2.2.1",
     "jest": "^27.4.7",
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.2",

--- a/packages/@pandino/pandino-persistence-manager-localstorage/assets/pandino-persistence-manager-localstorage-manifest.json
+++ b/packages/@pandino/pandino-persistence-manager-localstorage/assets/pandino-persistence-manager-localstorage-manifest.json
@@ -4,6 +4,6 @@
   "Bundle-Name": "Pandino Localstorage Persistence Manager",
   "Bundle-Version": "0.1.0",
   "Bundle-Description": "Localstorage implementation of the Pandino Persistence Manager API",
-  "Bundle-Activator": "./pandino-persistence-manager-localstorage.js",
+  "Bundle-Activator": "./pandino-persistence-manager-localstorage.mjs",
   "Provide-Capability": "@pandino/persistence-manager;type=\"dom-localstorage\";objectClass=\"@pandino/persistence-manager/PersistenceManager\""
 }

--- a/packages/@pandino/pandino-persistence-manager-localstorage/package.json
+++ b/packages/@pandino/pandino-persistence-manager-localstorage/package.json
@@ -2,7 +2,13 @@
   "name": "@pandino/pandino-persistence-manager-localstorage",
   "version": "0.1.0",
   "description": "Localstorage implementation of the Pandino Persistence Manager API",
-  "main": "dist/pandino-persistence-manager-memory.js",
+  "type": "module",
+  "module": "./dist/pandino-persistence-manager-localstorage.mjs",
+  "exports": {
+    ".": {
+      "default": "./dist/pandino-persistence-manager-localstorage.mjs"
+    }
+  },
   "private": true,
   "types": "dist/src/index.d.ts",
   "scripts": {

--- a/packages/@pandino/pandino-persistence-manager-localstorage/webpack.config.js
+++ b/packages/@pandino/pandino-persistence-manager-localstorage/webpack.config.js
@@ -1,8 +1,13 @@
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
-const path = require('path');
-const CopyPlugin = require('copy-webpack-plugin');
+import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
+import path from 'path';
+import CopyPlugin from 'copy-webpack-plugin';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 
-module.exports = {
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default {
   experiments: {
     outputModule: true,
   },
@@ -24,10 +29,8 @@ module.exports = {
     extensions: ['.tsx', '.ts', '.js'],
   },
   output: {
-    filename: '[name].js',
-    library: {
-      type: 'module',
-    },
+    filename: '[name].mjs',
+    libraryTarget: 'module',
     umdNamedDefine: true,
     path: path.resolve(__dirname, 'dist'),
   },


### PR DESCRIPTION
refactor: these packages are now compatible with:
 - pandino-bundle-installer-dom: only ESM
 - pandino-configuration-management: CJS and ESM
 - pandino-persistence-manager-localstorage: only ESM